### PR TITLE
Put RNG in shared memory in TransportElectrons

### DIFF
--- a/examples/TestEm3/TestEm3.cuh
+++ b/examples/TestEm3/TestEm3.cuh
@@ -17,7 +17,7 @@
 #include <VecGeom/base/Vector3D.h>
 #include <VecGeom/navigation/NavStateIndex.h>
 
-constexpr int ThreadsPerBlock    = 256;
+constexpr int ThreadsPerBlock    = 128;
 constexpr int ThreadsPerSM       = 256;
 constexpr int BlocksPerSM        = ThreadsPerSM / ThreadsPerBlock;
 constexpr int RegistersPerThread = 64 * 1024 / ThreadsPerSM;


### PR DESCRIPTION
All measurements on my RTX 2060.

Before:
Mean: 1.76788
Uncertainty: 0.00101691

RNG in SM:
Mean: 1.74209
Uncertainty: 0.00110942

RNG in SM and 128 T/B for all kernels
Mean: 1.64645
Uncertainty: 0.000705663

RNG in SM and 128 T/B for only TransportElectrons
Mean: 1.73644
Uncertainty: 0.0043997

I guess the threads/block will become a tuning parameter for the GPU we are running on?

The RNG state has 80 bytes, times the 256 threads, amounts to 20480 bytes. By GPU has 49152 bytes SM, so that would allow only two blocks per SM at the same time. By reducing the threads to 128, I assume that we can get more of them onto a single SM. But I have not checked in the profiler. This might again look different on the V100.