### PR TITLE
Avoid inlining RanluxppEngineImpl::Advance

### DIFF
--- a/base/inc/CopCore/include/CopCore/Ranluxpp.h
+++ b/base/inc/CopCore/include/CopCore/Ranluxpp.h
@@ -53,7 +53,8 @@ public:
   RanluxppEngineImpl() = default;
 
   /// Produce next block of random bits
-  __host__ __device__ void Advance()
+  // We avoid inlining here because Advance() contributes a LOT of code which nvcc duplicates into several places.
+  __noinline__ __host__ __device__ void Advance()
   {
     uint64_t lcg[9];
     to_lcg(fState, fCarry, lcg);


### PR DESCRIPTION
Advance contributes a lot of code to the kernel and nvcc duplicates it into several places. This change also improves performance a bit.

Before:
Mean: 1.76788
Uncertainty: 0.00101691

After:
Mean: 1.69071
Uncertainty: 0.000880195